### PR TITLE
기본 페이지 구조와 라우터 구현

### DIFF
--- a/src/core/Component.js
+++ b/src/core/Component.js
@@ -1,0 +1,47 @@
+class Component {
+  $target;
+  $props;
+  $state;
+
+  constructor($target, $props) {
+    this.$target = $target;
+    this.$props = $props;
+    this.render();
+    this.setup();
+    this.setEvent();
+  }
+
+  setup() {}
+
+  mounted() {}
+
+  template() {
+    return "";
+  }
+
+  render() {
+    this.$target.innerHTML = this.template();
+    this.mounted(); // render 이후 실행
+  }
+
+  setEvent() {}
+
+  setState(newState) {
+    this.$state = { ...this.$state, ...newState };
+    this.render();
+  }
+
+  addEvent(eventType, selector, callback) {
+    const children = [...this.$target.querySelectorAll(selector)];
+    // selector에 명시한 것 보다 더 하위 요소가 선택되는 경우가 있을 땐 closest를 이용하여 처리 (closest => selector와 일치하는 가장 가까운 부모 탐색)
+    const isTarget = (target) =>
+      children.includes(target) || target.closest(selector);
+
+    this.$target.addEventListener(eventType, (event) => {
+      if (!isTarget(event.target)) return false;
+      callback(event);
+    });
+  }
+}
+
+export default Component;

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,3 @@
+const { initializeRouter } = require("./router");
 
+initializeRouter();

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -1,0 +1,15 @@
+import Component from "../core/Component";
+
+class Edit extends Component {
+  template() {
+    return `
+    <main>
+      <header class='header'>header</header>
+      <div>글 수정</div>
+      <div>글 내용</div>
+    </main>
+    `;
+  }
+}
+
+export default Edit;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,0 +1,15 @@
+import Component from "../core/Component.js";
+
+class Home extends Component {
+  template() {
+    return `
+    <main>
+      <header class='header'></header>
+      <div>글작성 버튼</div>
+      <ul>글 목록</ul>
+    </main>
+    `;
+  }
+}
+
+export default Home;

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,0 +1,14 @@
+import Component from "../core/Component";
+
+class NotFound extends Component {
+  template() {
+    return `
+    <main>
+      <div>404 페이지</div>
+      <div>메인 페이지로 이동</div>
+    </main>
+    `;
+  }
+}
+
+export default NotFound;

--- a/src/pages/Post.js
+++ b/src/pages/Post.js
@@ -1,0 +1,15 @@
+import Component from "../core/Component";
+
+class Post extends Component {
+  template() {
+    return `
+    <main>
+      <header class='header'>header</header>
+      <div>글 상세 페이지</div>
+      <div>글 내용</div>
+    </main>
+    `;
+  }
+}
+
+export default Post;

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -1,0 +1,15 @@
+import Component from "../core/Component.js";
+
+class Upload extends Component {
+  template() {
+    return `
+    <main>
+      <header class='header'>header</header>
+      <div>글작성 페이지</div>
+      <div>글 내용</div>
+    </main>
+    `;
+  }
+}
+
+export default Upload;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,7 @@
+import Edit from "./Edit.js";
+import Home from "./Home.js";
+import Upload from "./Upload.js";
+import Post from "./Post.js";
+import NotFound from "./NotFound.js";
+
+export { Home, Post, Upload, Edit, NotFound };

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,37 @@
+import { Edit, Home, NotFound, Post, Upload } from "./pages/index.js";
+
+const root = document.querySelector("#app");
+
+const routes = [
+  { path: "/", component: Home },
+  { path: "/post/:id", component: Post },
+  { path: "/upload", component: Upload },
+  { path: "/edit/:id", component: Edit },
+];
+
+const render = (path) => {
+  const matchedRoutes = routes.map((route) => {
+    const isMatch = path.match(pathToRegex(route.path));
+    return { route, isMatch };
+  });
+
+  const match = matchedRoutes.find(
+    (matchedRoute) => matchedRoute.isMatch !== null
+  );
+
+  match ? new match.route.component(root) : new NotFound(root);
+};
+
+const pathToRegex = (path) =>
+  new RegExp("^" + path.replace(/\//g, "\\/").replace(/:\w+/g, "(.+)") + "$");
+
+export const navigateTo = (path) => {
+  window.history.pushState({}, "", window.location.origin + path);
+  render(path);
+};
+
+export const initializeRouter = () => {
+  window.addEventListener("DOMContentLoaded", () => {
+    render(window.location.pathname);
+  });
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
     filename: "bundle.js",
     path: path.resolve(__dirname, "dist"),
     clean: true,
+    publicPath: "/",
   },
   devServer: { port: 3000, hot: true, historyApiFallback: true },
   module: {


### PR DESCRIPTION
## 💬 작업 내역
- [x] 기능 추가 : 추상 클래스 작성, 기본 페이지 구조 설정, router 코드 작성
- [x] 개발 환경 세팅 : webpack 설정 수정

## 💬 전달사항
- 라우터를 구현한 프로젝트에서 webpack의 devServer에 historyApiFallback: true, output에 publicPath: "/"를 모두 설정하자
  - historyApiFallback : 어플리케이션에는 기본 주소(예시. localhost:3000)만 연결됐는데 localhost:3000/upload 페이지로 검색해서 이동할때 원래 띄워야하는 404페이지를 index.html로 서빙해주는 역할을 한다.
  -  publicPath : 어플리케이션의 모든 코드의 기본 경로를 ‘/’로 설정하는 개념이다.

## 💬 Issue Number
close : #3
