### PR TITLE
기존 Components 추상 클래스 분리

### DIFF
--- a/src/components/CommentInput/index.js
+++ b/src/components/CommentInput/index.js
@@ -15,12 +15,9 @@ class CommentInput extends Component {
   }
 
   mounted() {
-    const commentSubmitButton = document.querySelector(
-      ".comment_submit_container"
-    );
-
-    new Button(commentSubmitButton, {
+    new Button(this.$props.form, {
       content: `게시`,
+      className: `comment_submit`,
       onClick: () => this.$createComment(this.$props.params, this.$content),
     });
   }

--- a/src/components/CommentItem/index.js
+++ b/src/components/CommentItem/index.js
@@ -1,23 +1,14 @@
 import { deleteComment } from "../../apis/comment";
 import Component from "../../core/Component";
 
-class CommentList extends Component {
+class CommentItem extends Component {
   template() {
-    if (this.$props.commentList) {
-      const htmlStr = this.$props.commentList
-        ?.map(
-          ({ content, commentId }) =>
-            `<li class='comment_item'>
+    const { content, commentId } = this.$props.comment;
+
+    return `<li class='comment_item'>
               <p class='comment_content'>${content}</p>
               <button class='comment_delete' data-comment-id=${commentId}>삭제</button>
-            </li>`
-        )
-        .join("");
-
-      return htmlStr;
-    }
-
-    return ``;
+            </li>`;
   }
 
   setEvent() {
@@ -30,4 +21,4 @@ class CommentList extends Component {
   }
 }
 
-export default CommentList;
+export default CommentItem;

--- a/src/components/PostDetail/index.js
+++ b/src/components/PostDetail/index.js
@@ -7,11 +7,13 @@ class postDetail extends Component {
       const convertedTime = this.getStringDate(new Date(createdAt));
 
       return `
-        <img src=${image} alt="게시글 이미지"/>
-        <strong class="post_detail_title">${title}</strong>
-        <time datetime=${createdAt}>${convertedTime}</time>
-        <p class="post_detail_content">${content}</p>
-      `;
+            <div>
+              <img src=${image} alt="게시글 이미지"/>
+              <strong class="post_detail_title">${title}</strong>
+              <time datetime=${createdAt}>${convertedTime}</time>
+              <p class="post_detail_content">${content}</p>
+            </div>
+        `;
     }
 
     return ``;

--- a/src/components/PostItem/index.js
+++ b/src/components/PostItem/index.js
@@ -3,22 +3,16 @@ import { navigateTo } from "../../router";
 
 class PostItem extends Component {
   template() {
-    const htmlStr = this.$props.posts
-      ?.map(
-        (post) =>
-          `
-          <li class="post_item_container" data-post-id=${post.postId}>
-            <img src=${post.image} alt="사용자가 올린 글의 이미지"/>
+    const { postId, image, title, content } = this.$props.post;
+    return `
+          <li class="post_item_container" data-post-id=${postId}>
+            <img src=${image} alt="사용자가 올린 글의 이미지"/>
             <div class="post_content_container">
-              <strong class="post_title">${post.title}</strong>
-              <p class="post_content">${post.content}</p>
+              <strong class="post_title">${title}</strong>
+              <p class="post_content">${content}</p>
             </div>
           </li>
-          `
-      )
-      .join("");
-
-    return htmlStr;
+          `;
   }
 
   setEvent() {

--- a/src/components/PostList/index.js
+++ b/src/components/PostList/index.js
@@ -1,30 +1,21 @@
-import { getPostList } from "../../apis/post";
 import Component from "../../core/Component";
 import PostItem from "../PostItem";
 
 class PostList extends Component {
   template() {
     return `
-      <ul class="post_list_container"></ul>
+      <ul class="post_list"></ul>
     `;
   }
 
-  setup() {
-    this.$state = {};
-    this.$getPostList();
-  }
-
-  async $getPostList() {
-    const { data } = await getPostList();
-    this.setState({ posts: data.posts });
-  }
-
   mounted() {
-    const $postList = document.querySelector(".post_list_container");
+    const $postList = document.querySelector(".post_list");
 
-    if (this.$state) {
-      new PostItem($postList, {
-        posts: this.$state.posts,
+    if (this.$props.posts) {
+      this.$props.posts.map((post) => {
+        new PostItem($postList, {
+          post,
+        });
       });
     }
   }

--- a/src/components/common/Button/index.js
+++ b/src/components/common/Button/index.js
@@ -2,39 +2,22 @@ import Component from "../../../core/Component";
 
 class Button extends Component {
   template() {
-    if (this.$props.length) {
-      const htmlStr = this.$props
-        .map(
-          ({ content, className }) => `
-            <button class='button ${className}' data-button-content=${content}>${content}</button>
-          `
-        )
-        .join("");
-      return htmlStr;
-    }
-
     const { content, className } = this.$props;
     return `
-      <button class=button ${className}>${content}</button>
+      <button class="button ${className ? className : ""}">${content}</button>
     `;
   }
 
   setEvent() {
-    if (this.$props.length) {
-      this.$props.forEach(({ className, onClick }) => {
-        this.addEvent("click", `.${className.split(" ")[0]}`, (e) => {
-          e.preventDefault();
-          onClick();
-        });
-      });
-      return;
-    }
-
-    const { onClick } = this.$props;
-    this.addEvent("click", ".button", (e) => {
-      e.preventDefault();
-      onClick();
-    });
+    const { onClick, className } = this.$props;
+    this.addEvent(
+      "click",
+      className ? `.${className.split(" ")[0]}` : ".button",
+      (e) => {
+        e.preventDefault();
+        onClick();
+      }
+    );
   }
 }
 

--- a/src/components/common/Header/index.js
+++ b/src/components/common/Header/index.js
@@ -6,25 +6,16 @@ import leftArrowIcon from "../../../assets/icon_arrow_back.svg";
 import "../../../styles/header.scss";
 
 class Header extends Component {
-  template() {
-    return `
-    <div class='button_container'></div>
-    <div class='title_container'></div>
-    `;
-  }
-
   mounted() {
-    const $backButton = this.$target.querySelector(".button_container");
-    const $titleButton = this.$target.querySelector(".title_container");
-
     const isHomePage = window.location.pathname === "/";
-    if (isHomePage) $backButton.style.display = "none";
 
-    new Button($backButton, {
-      content: `<img src=${leftArrowIcon} alt="뒤로가기 버튼" class="back_arrow_img"/>`,
-      onClick: this.goBackPage,
-    });
-    new Button($titleButton, {
+    if (!isHomePage) {
+      new Button(this.$props.header, {
+        content: `<img src=${leftArrowIcon} alt="뒤로가기 버튼" class="back_arrow_img"/>`,
+        onClick: this.goBackPage,
+      });
+    }
+    new Button(this.$props.header, {
       content: `<h1 class="header_title">HPNY 2023</h1>`,
       onClick: this.goHomePage,
     });

--- a/src/core/Component.js
+++ b/src/core/Component.js
@@ -1,45 +1,21 @@
-class Component {
-  $target;
-  $props;
-  $state;
+import Page from "./Page";
 
-  constructor($target, $props) {
-    this.$target = $target;
-    this.$props = $props;
-    this.setup();
-    this.setEvent();
-    this.render();
-  }
-
-  setup() {}
-
-  mounted() {}
-
-  template() {
-    return "";
-  }
-
+class Component extends Page {
   render() {
-    this.$target.innerHTML = this.template();
+    if (this.template().length > 0)
+      this.$target.appendChild(this.parseNodeFromString(this.template()));
     this.mounted();
   }
 
-  setEvent() {}
+  parseNodeFromString(htmlString) {
+    const domParser = new DOMParser();
 
-  setState(newState) {
-    this.$state = { ...this.$state, ...newState };
-    this.render();
-  }
+    const node = domParser.parseFromString(htmlString, "text/html").body
+      .firstChild;
 
-  addEvent(eventType, selector, callback) {
-    const children = [...this.$target.querySelectorAll(selector)];
-    const isTarget = (target) =>
-      children.includes(target) || target.closest(selector);
+    node.normalize();
 
-    this.$target.addEventListener(eventType, (event) => {
-      if (!isTarget(event.target)) return false;
-      callback(event);
-    });
+    return node;
   }
 }
 

--- a/src/core/Page.js
+++ b/src/core/Page.js
@@ -1,0 +1,46 @@
+class Page {
+  $target;
+  $props;
+  $state;
+
+  constructor($target, $props) {
+    this.$target = $target;
+    this.$props = $props;
+    this.setup();
+    this.setEvent();
+    this.render();
+  }
+
+  setup() {}
+
+  mounted() {}
+
+  template() {
+    return "";
+  }
+
+  render() {
+    this.$target.innerHTML = this.template();
+    this.mounted();
+  }
+
+  setState(newState) {
+    this.$state = { ...this.$state, ...newState };
+    this.render();
+  }
+
+  setEvent() {}
+
+  addEvent(eventType, selector, callback) {
+    const children = [...this.$target.querySelectorAll(selector)];
+    const isTarget = (target) =>
+      children.includes(target) || target.closest(selector);
+
+    this.$target.addEventListener(eventType, (event) => {
+      if (!isTarget(event.target)) return false;
+      callback(event);
+    });
+  }
+}
+
+export default Page;

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -1,7 +1,7 @@
 import Header from "../components/common/Header";
-import Component from "../core/Component";
+import Page from "../core/Page";
 
-class Edit extends Component {
+class Edit extends Page {
   template() {
     return `
     <header class='header'></header>
@@ -14,7 +14,9 @@ class Edit extends Component {
   mounted() {
     const $header = document.querySelector(".header");
 
-    new Header($header);
+    new Header($header, {
+      header: $header,
+    });
   }
 }
 

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,20 +1,26 @@
+import { getPostList } from "../apis/post";
 import Button from "../components/common/Button";
 import Header from "../components/common/Header/index";
 import PostList from "../components/PostList";
-import Component from "../core/Component";
+import Page from "../core/Page";
 import { navigateTo } from "../router";
 
 import "../styles/home.scss";
 
-class Home extends Component {
+class Home extends Page {
   template() {
     return `
     <header class='header' style="justify-content:flex-end"></header>
     <main>
       <div class='upload_post_button_container'></div>
-      <section class='post_list_container'>글 목록</section>
+      <section class='post_list_container'></section>
     </main>
     `;
+  }
+
+  setup() {
+    this.$state = {};
+    this.$getPostList();
   }
 
   mounted() {
@@ -24,16 +30,25 @@ class Home extends Component {
     );
     const $postListContainer = document.querySelector(".post_list_container");
 
-    new Header($header);
+    new Header($header, {
+      header: $header,
+    });
     new Button($uploadButtonContainer, {
       content: `게시글 작성하기`,
       onClick: this.goUploadPage,
     });
-    new PostList($postListContainer);
+    new PostList($postListContainer, {
+      posts: this.$state.posts,
+    });
   }
 
   goUploadPage() {
     navigateTo("/upload");
+  }
+
+  async $getPostList() {
+    const { data } = await getPostList();
+    this.setState({ posts: data.posts });
   }
 }
 

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,6 +1,6 @@
-import Component from "../core/Component";
+import Page from "../core/Page";
 
-class NotFound extends Component {
+class NotFound extends Page {
   template() {
     return `
     <main>

--- a/src/pages/Post.js
+++ b/src/pages/Post.js
@@ -1,23 +1,25 @@
 import { deletePost, getPostDetail } from "../apis/post";
 import CommentInput from "../components/CommentInput";
-import CommentList from "../components/CommentList";
+import CommentItem from "../components/CommentItem";
 import Button from "../components/common/Button";
 import Header from "../components/common/Header";
 import postDetail from "../components/PostDetail";
-import Component from "../core/Component";
+import Page from "../core/Page";
 import { navigateTo } from "../router";
 
 import "../styles/post.scss";
 
-class Post extends Component {
+class Post extends Page {
   template() {
     return `
     <header class='header'></header>
     <main>
-      <div class='post_detail_container'></div>
-      <div class='edit_delete_button_container'></div>
-      <ul class='comment_list'></ul>
-      <form class='comment_form'></form>
+      <section class='post_detail_container'></section>
+      <div class='button_container'></div>
+      <section>
+        <ul class='comment_list'></ul>
+        <form class='comment_form'></form>
+      </section>
     </main>
     `;
   }
@@ -40,33 +42,41 @@ class Post extends Component {
   mounted() {
     const $header = document.querySelector(".header");
     const $postDetail = document.querySelector(".post_detail_container");
-    const $buttonContainer = document.querySelector(
-      ".edit_delete_button_container"
-    );
+    const $buttonContainer = document.querySelector(".button_container");
     const $commentList = document.querySelector(".comment_list");
     const $commentForm = document.querySelector(".comment_form");
 
-    new Header($header);
+    new Header($header, {
+      header: $header,
+    });
+
     new postDetail($postDetail, {
       post: this.$state.post,
     });
-    new Button($buttonContainer, [
-      {
-        content: `수정 📝`,
-        className: `post_edit`,
-        onClick: () => this.$goToEditPage(this.$params),
-      },
-      {
-        content: `삭제 🗑️`,
-        className: `post_delete`,
-        onClick: () => this.$deletePost(this.$params),
-      },
-    ]);
-    new CommentList($commentList, {
-      commentList: this.$state.comments,
-      deleteCommentState: (commentId) => this.$deleteCommentState(commentId),
+
+    new Button($buttonContainer, {
+      content: `수정 📝`,
+      className: `post_edit`,
+      onClick: () => this.$goToEditPage(this.$params),
     });
+    new Button($buttonContainer, {
+      content: `삭제 🗑️`,
+      className: `post_delete`,
+      onClick: () => this.$deletePost(this.$params),
+    });
+
+    if (this.$state.comments) {
+      this.$state.comments.map((comment) => {
+        new CommentItem($commentList, {
+          comment,
+          deleteCommentState: (commentId) =>
+            this.$deleteCommentState(commentId),
+        });
+      });
+    }
+
     new CommentInput($commentForm, {
+      form: $commentForm,
       params: this.$params,
       createCommentState: (newComment) => this.$createCommentState(newComment),
     });

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -1,7 +1,7 @@
 import Header from "../components/common/Header/index";
-import Component from "../core/Component";
+import Page from "../core/Page";
 
-class Upload extends Component {
+class Upload extends Page {
   template() {
     return `
     <header class='header'></header>
@@ -15,7 +15,9 @@ class Upload extends Component {
   mounted() {
     const $header = document.querySelector(".header");
 
-    new Header($header);
+    new Header($header, {
+      header: $header,
+    });
   }
 }
 

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -23,7 +23,7 @@ main {
     }
   }
 
-  .post_list_container {
+  .post_list {
     display: flex;
     flex-direction: column;
 

--- a/src/styles/post.scss
+++ b/src/styles/post.scss
@@ -41,7 +41,7 @@ main {
     }
   }
 
-  .edit_delete_button_container {
+  .button_container {
     display: flex;
     justify-content: flex-end;
     gap: 1rem;
@@ -131,7 +131,7 @@ main {
       }
     }
 
-    .comment_submit_container {
+    .comment_submit {
       width: 20%;
 
       background-color: #fafafa;
@@ -141,12 +141,9 @@ main {
       border-top-right-radius: 8px;
       border-bottom-right-radius: 8px;
 
-      text-align: center;
+      padding: 10px 0px;
 
-      button {
-        width: 100%;
-        padding: 10px 0px;
-      }
+      text-align: center;
     }
   }
 }


### PR DESCRIPTION
## 💬 작업 내역
- [x] 리팩토링 : Component 클래스를 Page와 Component로 분리 (Page가 상위 클래스)


## 💬 전달사항
- page는 처음 render될때 innerHTML로 추가되는게 더 적절해보여서 그대로 사용했다.
- component는 template을 DOM Node로 변환하여 부모 selector에 appendChild 했다.

이 작업을 통해 이젠 `new Button("a", {content: "1"}), new Button("a", {content: "2"}` 코드가 있다면 content: "1"인 버튼과 content: "2"인 버튼 두개가 생긴다.
(의미없이 selector를 위한 상위 element를 만들지 않아도 됨)

## 💬 Issue Number
close : #19 
