### PR TITLE
Edit Page UI && 기능 구현

### DIFF
--- a/src/apis/post.js
+++ b/src/apis/post.js
@@ -31,7 +31,7 @@ export const uploadPost = async (postData) => {
   }
 };
 
-export const editPost = async (postData, postId) => {
+export const patchPost = async (postData, postId) => {
   try {
     const { data } = await baseInstance.patch(`/post/${postId}`, postData);
     return data;

--- a/src/apis/post.js
+++ b/src/apis/post.js
@@ -33,7 +33,7 @@ export const uploadPost = async (postData) => {
 
 export const editPost = async (postData, postId) => {
   try {
-    const { data } = await baseInstance.put(`/post/${postId}`, postData);
+    const { data } = await baseInstance.patch(`/post/${postId}`, postData);
     return data;
   } catch (err) {
     return console.error(err);

--- a/src/components/common/Button/index.js
+++ b/src/components/common/Button/index.js
@@ -3,7 +3,6 @@ import Component from "../../../core/Component";
 class Button extends Component {
   template() {
     const { content, className, disabled } = this.$props;
-    console.log(disabled);
     return `
       <button class="${className ? className : "button"}" ${
       disabled ? "disabled" : ""

--- a/src/components/common/Header/index.js
+++ b/src/components/common/Header/index.js
@@ -12,17 +12,23 @@ class Header extends Component {
     if (!isHomePage) {
       new Button(this.$props.header, {
         content: `<img src=${leftArrowIcon} alt="뒤로가기 버튼" class="back_arrow_img"/>`,
+        className: "back_button",
         onClick: this.goBackPage,
       });
     }
     new Button(this.$props.header, {
       content: `<h1 class="header_title">HPNY 2023</h1>`,
+      className: "logo",
       onClick: this.goHomePage,
     });
   }
 
   goBackPage() {
-    history.back();
+    if (window.location.pathname.split("/")[1] === "post") {
+      navigateTo("/");
+    } else {
+      history.back();
+    }
   }
 
   goHomePage() {

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -1,9 +1,11 @@
-import { getPostDetail } from "../apis/post";
+import { getPostDetail, patchPost } from "../apis/post";
+import { getRandomImage } from "../apis/unsplash";
 import Button from "../components/common/Button";
 import Header from "../components/common/Header";
 import Input from "../components/common/Input";
 import TextArea from "../components/common/TextArea";
 import Page from "../core/Page";
+import { navigateTo } from "../router";
 
 import "../styles/edit.scss";
 
@@ -19,9 +21,8 @@ class Edit extends Page {
   }
 
   async setup() {
-    const data = await this.$getExistentData(
-      window.location.pathname.split("/")[2]
-    );
+    this.$params = window.location.pathname.split("/")[2];
+    const data = await this.$getExistentData(this.$params);
 
     this.setState({
       title: data.title,
@@ -41,36 +42,64 @@ class Edit extends Page {
       const isValidPost = !!title && !!content && !!image;
       const $header = document.querySelector(".header");
       const $editDataContainer = document.querySelector(".edit_data_container");
+
       new Header($header, {
         header: $header,
       });
+
       new Button($editDataContainer, {
         content: `<img src="${this.$state.image}" alt="" />`,
         className: "random_image_button",
-        // onClick: () => this.$handleImage(),
+        onClick: () => this.$handleImage(),
       });
+
       new Input($editDataContainer, {
         type: "text",
         placeholder: "제목을 입력하세요 !",
         value: title,
         className: "upload_title",
-        // onChange: (text) => this.$handleTitle(text),
+        onChange: (text) => this.$handleTitle(text),
       });
+
       new TextArea($editDataContainer, {
-        name: "uploadContent",
+        name: "editContent",
         rows: 10,
         maxlength: 500,
         placeholder: "내용을 입력하세요 !",
         value: content,
         className: "upload_content",
-        // onChange: (text) => this.$handleContent(text),
+        onChange: (text) => this.$handleContent(text),
       });
+
       new Button($editDataContainer, {
-        content: "업로드",
+        content: "수정하기",
         disabled: !isValidPost,
         className: isValidPost ? "post_upload_button" : "invalid_button",
-        // onClick: () => this.$createPost(),
+        onClick: () => this.$patchPost(),
       });
+    }
+  }
+
+  async $handleImage() {
+    const data = await getRandomImage();
+    this.setState({ image: data.urls.full });
+  }
+
+  $handleTitle(text) {
+    this.setState({ title: text });
+  }
+
+  $handleContent(text) {
+    this.setState({ content: text });
+  }
+
+  async $patchPost() {
+    const data = await patchPost(this.$state, this.$params);
+    console.log(data);
+    if (data.code === 200) {
+      navigateTo(`/post/${this.$params}`);
+    } else {
+      alert(data.response.data.message);
     }
   }
 }

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -1,22 +1,77 @@
+import { getPostDetail } from "../apis/post";
+import Button from "../components/common/Button";
 import Header from "../components/common/Header";
+import Input from "../components/common/Input";
+import TextArea from "../components/common/TextArea";
 import Page from "../core/Page";
+
+import "../styles/edit.scss";
 
 class Edit extends Page {
   template() {
     return `
     <header class='header'></header>
     <main>
-      <div>글수정 버튼</div>
-      <ul>글 내용</ul>
+      <section class='edit_data_container'>
+      </section>
     </main>
     `;
   }
-  mounted() {
-    const $header = document.querySelector(".header");
 
-    new Header($header, {
-      header: $header,
+  async setup() {
+    const data = await this.$getExistentData(
+      window.location.pathname.split("/")[2]
+    );
+
+    this.setState({
+      title: data.title,
+      content: data.content,
+      image: data.image,
     });
+  }
+
+  async $getExistentData(postId) {
+    const { data } = await getPostDetail(postId);
+    return data.post;
+  }
+
+  mounted() {
+    if (this.$state) {
+      const { title, content, image } = this.$state;
+      const isValidPost = !!title && !!content && !!image;
+      const $header = document.querySelector(".header");
+      const $editDataContainer = document.querySelector(".edit_data_container");
+      new Header($header, {
+        header: $header,
+      });
+      new Button($editDataContainer, {
+        content: `<img src="${this.$state.image}" alt="" />`,
+        className: "random_image_button",
+        // onClick: () => this.$handleImage(),
+      });
+      new Input($editDataContainer, {
+        type: "text",
+        placeholder: "제목을 입력하세요 !",
+        value: title,
+        className: "upload_title",
+        // onChange: (text) => this.$handleTitle(text),
+      });
+      new TextArea($editDataContainer, {
+        name: "uploadContent",
+        rows: 10,
+        maxlength: 500,
+        placeholder: "내용을 입력하세요 !",
+        value: content,
+        className: "upload_content",
+        // onChange: (text) => this.$handleContent(text),
+      });
+      new Button($editDataContainer, {
+        content: "업로드",
+        disabled: !isValidPost,
+        className: isValidPost ? "post_upload_button" : "invalid_button",
+        // onClick: () => this.$createPost(),
+      });
+    }
   }
 }
 

--- a/src/pages/Post.js
+++ b/src/pages/Post.js
@@ -57,7 +57,7 @@ class Post extends Page {
     new Button($buttonContainer, {
       content: `수정 📝`,
       className: `post_edit`,
-      onClick: () => this.$goToEditPage(this.$params),
+      onClick: () => this.$goToEditPage(this.$params, this.$state.post),
     });
     new Button($buttonContainer, {
       content: `삭제 🗑️`,
@@ -82,8 +82,8 @@ class Post extends Page {
     });
   }
 
-  $goToEditPage(postId) {
-    navigateTo(`/edit/${postId}`);
+  $goToEditPage(postId, state) {
+    navigateTo(`/edit/${postId}`, state);
   }
 
   $goToHomePage() {

--- a/src/styles/edit.scss
+++ b/src/styles/edit.scss
@@ -1,0 +1,56 @@
+main {
+  .edit_data_container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+
+    * {
+      width: 100%;
+      border-radius: 1rem;
+    }
+
+    .random_image_button {
+      img {
+        width: 100%;
+        height: 23rem;
+        object-fit: cover;
+      }
+    }
+
+    .upload_title {
+      padding: 1rem;
+      border: 1px solid rgba($color: #000000, $alpha: 0.6);
+
+      &:active,
+      &:focus {
+        border: 2px solid #164ea9;
+      }
+    }
+
+    .upload_content {
+      padding: 1rem;
+      resize: none;
+      border: 1px solid rgba($color: #000000, $alpha: 0.6);
+
+      &:active,
+      &:focus {
+        border: 2px solid #164ea9;
+      }
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+
+    .post_upload_button {
+      padding: 1rem;
+      background-color: #0095f6;
+      color: #ffffff;
+    }
+
+    .invalid_button {
+      padding: 1rem;
+      background-color: #dddddd;
+    }
+  }
+}


### PR DESCRIPTION
## 💬 작업 내역
- [x] 기능 추가 : 기존 글 내역을 불러와 patch 하는 기능
- [x] 마크업 & 스타일 : Edit Page UI 구현


## 💬 전달사항
- 기존 post의 data를 불러오는 2가지 방법을 고민하다 새로 api를 호출하는 방식으로 진행
  - navigateTo로 router가 이동할때 state를 넘겨주는 방법(react의 navigate에 state를 넘겨주는 방법과 유사)
    - 단점: 데이터는 잘 넘어가지만 edit page에서 새로고침할 경우 데이터를 잃어버림
  - edit page에서 render를 진행할때 setState에 api get으로 post/id의 데이터를 불러와 추가
    - 새로고침해도 데이터를 다시 불러오기 때문에 데이터가 유지되지만, api를 호출하기 때문에 자원과 시간이 소요됨   


## 💬 스크린샷
![edit numble](https://user-images.githubusercontent.com/71367408/213242592-88a35359-008c-48be-9c80-4bbd3963c711.gif)


## 💬 Issue Number
close : #22 
