### PR TITLE
댓글 리스트 삭제 에러 수정

### DIFF
--- a/src/components/CommentItem/index.js
+++ b/src/components/CommentItem/index.js
@@ -12,9 +12,8 @@ class CommentItem extends Component {
   }
 
   setEvent() {
-    this.addEvent("click", ".comment_delete", async (e) => {
-      const commentId = e.target.dataset.commentId;
-
+    const { commentId } = this.$props.comment;
+    this.addEvent("click", `[data-comment-id="${commentId}"]`, async () => {
       await deleteComment(commentId);
       this.$props.deleteCommentState(commentId);
     });


### PR DESCRIPTION
- 삭제 이벤트의 selector를 모두 같게 줘서 이벤트가 겹치는 현상 발생 => 유니크한 값을 selector로 변경

## 💬 작업 내역
- [x] 버그 수정 : 삭제 이벤트의 selector를 모두 같게 줘서 이벤트가 겹치는 현상 발생 => 유니크한 값을 selector로 변경

